### PR TITLE
Update to use local TimeZone.

### DIFF
--- a/DiscoverScheduledTasks.ps1
+++ b/DiscoverScheduledTasks.ps1
@@ -72,7 +72,7 @@ $pathtask1 = $pathtask.Taskpath
 $taskResult = Get-ScheduledTaskInfo -TaskPath "$pathtask1" -TaskName "$name1"
 $taskResult1 = $taskResult.LastRunTime
 $date = get-date -date "01/01/1970"
-$taskResult2 = (New-TimeSpan -Start $date -end $taskresult1).TotalSeconds
+$taskResult2 = Convert-ToUnixDate($taskResult1)
 Write-Output ($taskResult2)
 }}
 
@@ -85,7 +85,7 @@ $pathtask1 = $pathtask.Taskpath
 $taskResult = Get-ScheduledTaskInfo -TaskPath "$pathtask1" -TaskName "$name1"
 $taskResult1 = $taskResult.NextRunTime
 $date = get-date -date "01/01/1970"
-$taskResult2 = (New-TimeSpan -Start $date -end $taskresult1).TotalSeconds
+$taskResult2 = Convert-ToUnixDate($taskResult1)
 Write-Output ($taskResult2)
 }}
 


### PR DESCRIPTION
I had problems with the date display when running the script on the server, TimeZone was correct on the monitored server and on the Zabbix Server, but with the previous line it returned UTC-3. I took advantage of the function that already existed and updated the logic, it worked for America / Sao_Paulo.

I believe that other people may have the same scenario and with the change will be corrected.